### PR TITLE
Parse negative integers

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -528,6 +528,11 @@ ast::ExprPtr Parser::parseUnary() {
       continue; // parseUnary();
       break;
     default:
+      if (curTok.type == TT::IntLiteral && !unaries.empty() &&
+          unaries.back().type == TT::Minus) {
+        curTok.str = "-" + curTok.str;
+        unaries.pop_back();
+      }
       auto expression = parsePostfixExpr();
       auto endPos = expression->getLoc().endToken;
       // result = ...

--- a/src/pprinter.hpp
+++ b/src/pprinter.hpp
@@ -263,7 +263,12 @@ public:
   }
 
   void visitIntLiteral(ast::IntLiteral &intLiteral) override {
-    requireParenthesis = false;
+    maybePlaceParenthesis<ast::IntLiteral>(
+        intLiteral, &PrettyPrinterVisitor::visitIntLiteralHelper);
+  }
+
+  void visitIntLiteralHelper(ast::IntLiteral &intLiteral) {
+    requireParenthesis = intLiteral.getValue() < 0 ? true : false;
     stream << std::to_string(intLiteral.getValue());
   }
 


### PR DESCRIPTION
turns out the java standard has something to say about that… ☹

> The decimal literal 2147483648 may appear only as the operand of the unary minus operator - (§15.15.4).

See https://github.com/mj3-16/mjtest/pull/17#pullrequestreview-9247536

---

Ich denke es ist am einfachsten das beim ast Aufbau zu berücksichtigen, sonst brauchen wir größere int values um `2147483648` speichern zu können und müssen die später wieder konvertieren damit die Arithmetik passt...