### PR TITLE
accept null where we should

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -95,6 +95,17 @@ struct Type {
       return this->kind == other.kind;
     }
   }
+  bool operator>=(const sem::Type &other) const {
+    switch (this->kind) {
+    case TypeKind::Class:
+    case TypeKind::Array:
+      if (other.kind == TypeKind::Null) {
+        return true;
+      }
+    default:
+      return *this == other;
+    }
+  }
   bool operator!=(const sem::Type &other) const { return !(*this == other); }
 };
 


### PR DESCRIPTION
Ist bisschen magic mit dem operator, aber ich fands schöner als `sometype.canCastTo(othertype)`